### PR TITLE
Fix bug in nblist module

### DIFF
--- a/dmff/common/nblist.py
+++ b/dmff/common/nblist.py
@@ -48,7 +48,7 @@ class NeighborList:
         # jit_deco(self.nblist.update)(positions)
         self.nblist = self.nblist.update(positions)
         if self.nblist.did_buffer_overflow:
-            self.allocate(positions)
+            self.nblist = self.neighborlist_fn.allocate(positions)
         return self.nblist
     
     @property

--- a/dmff/common/nblist.py
+++ b/dmff/common/nblist.py
@@ -2,6 +2,7 @@ import jax.numpy as jnp
 from jax_md import space, partition
 from dmff.utils import jit_condition
 from dmff.utils import regularize_pairs
+from jax import jit
 
 
 class NeighborList:
@@ -45,8 +46,9 @@ class NeighborList:
         """
         # jit_deco = jit_condition()
         # jit_deco(self.nblist.update)(positions)
-        self.nblist.update(positions)
-        
+        self.nblist = self.nblist.update(positions)
+        if self.nblist.did_buffer_overflow:
+            self.allocate(positions)
         return self.nblist
     
     @property


### PR DESCRIPTION
Fix bug in nblist: when nblist is updated, should be
nbl = nbl.update(pos)
instead of:
nbl.update(pos)

Also, add an if statement, to judge if overflow happens. If overflow, reallocate.