### PR TITLE
Refactor `covalent_map` and `pairs` argument. 

### DIFF
--- a/dmff/admp/disp_pme.py
+++ b/dmff/admp/disp_pme.py
@@ -90,7 +90,7 @@ def energy_disp_pme(positions, box, pairs,
         box:
             3 * 3: box, axes arranged in row
         pairs:
-            Np * 2: interacting pair indices
+            Np * 3: interacting pair indices and topology distance
         c_list:
             Na * (pmax-4)/2: atomic dispersion coefficients
         mScales:
@@ -144,7 +144,7 @@ def disp_pme_real(positions, box, pairs,
         box:
             3 * 3: box, axes arranged in row
         pairs:
-            Np * 2: interacting pair indices
+            Np * 3: interacting pair indices and topology distance
         c_list:
             Na * (pmax-4)/2: atomic dispersion coefficients
         mScales:

--- a/dmff/admp/disp_pme.py
+++ b/dmff/admp/disp_pme.py
@@ -17,8 +17,8 @@ class ADMPDispPmeForce:
     The so called "environment paramters" means parameters that do not need to be differentiable
     '''
 
-    def __init__(self, box, covalent_map, rc, ethresh, pmax, lpme=True):
-        self.covalent_map = covalent_map
+    def __init__(self, box, rc, ethresh, pmax, lpme=True):
+
         self.rc = rc
         self.ethresh = ethresh
         self.pmax = pmax
@@ -44,7 +44,7 @@ class ADMPDispPmeForce:
     def generate_get_energy(self):
         def get_energy(positions, box, pairs, c_list, mScales):
             return energy_disp_pme(positions, box, pairs, 
-                                  c_list, mScales, self.covalent_map,
+                                  c_list, mScales,
                                   self.kappa, self.K1, self.K2, self.K3, self.pmax,
                                   self.d6_recip, self.d8_recip, self.d10_recip, lpme=self.lpme)
         return get_energy
@@ -78,7 +78,7 @@ class ADMPDispPmeForce:
 
 
 def energy_disp_pme(positions, box, pairs,
-        c_list, mScales, covalent_map,
+        c_list, mScales,
         kappa, K1, K2, K3, pmax, 
         recip_fn6, recip_fn8, recip_fn10, lpme=True):
     '''
@@ -115,7 +115,7 @@ def energy_disp_pme(positions, box, pairs,
     if lpme is False:
         kappa = 0
 
-    ene_real = disp_pme_real(positions, box, pairs, c_list, mScales, covalent_map, kappa, pmax)
+    ene_real = disp_pme_real(positions, box, pairs, c_list, mScales, kappa, pmax)
 
     if lpme:
         ene_recip = recip_fn6(positions, box, c_list[:, 0, jnp.newaxis])
@@ -132,7 +132,7 @@ def energy_disp_pme(positions, box, pairs,
 
 def disp_pme_real(positions, box, pairs, 
         c_list, 
-        mScales, covalent_map, 
+        mScales, 
         kappa, pmax):
     '''
     This function calculates the dispersion real space energy
@@ -162,16 +162,16 @@ def disp_pme_real(positions, box, pairs,
 
     # expand pairwise parameters
     # pairs = pairs[pairs[:, 0] < pairs[:, 1]]
-    pairs = regularize_pairs(pairs)
+    pairs = pairs.at[:, :2].set(regularize_pairs(pairs[:, :2]))
 
     box_inv = jnp.linalg.inv(box)
 
     ri = distribute_v3(positions, pairs[:, 0])
     rj = distribute_v3(positions, pairs[:, 1])
-    nbonds = covalent_map[pairs[:, 0], pairs[:, 1]]
+    nbonds = pairs[:, 2]
     mscales = distribute_scalar(mScales, nbonds-1)
 
-    buffer_scales = pair_buffer_scales(pairs)
+    buffer_scales = pair_buffer_scales(pairs[:, :2])
     mscales = mscales * buffer_scales
 
     ci = distribute_dispcoeff(c_list, pairs[:, 0])

--- a/dmff/admp/pairwise.py
+++ b/dmff/admp/pairwise.py
@@ -44,7 +44,7 @@ def distribute_dispcoeff(c_list, index):
 def distribute_matrix(multipoles,index1,index2):
     return multipoles[index1,index2]
 
-def generate_pairwise_interaction(pair_int_kernel, covalent_map, static_args):
+def generate_pairwise_interaction(pair_int_kernel, static_args):
     '''
     This is a calculator generator for pairwise interaction 
 
@@ -52,9 +52,6 @@ def generate_pairwise_interaction(pair_int_kernel, covalent_map, static_args):
         pair_int_kernel:
             function type (dr, m, p1i, p1j, p2i, p2j) -> energy : the vectorized kernel function, 
             dr is the distance, m is the topological scaling factor, p1i, p1j, p2i, p2j are pairwise parameters
-
-        covalent_map:
-            Na * Na, int: the covalent_map matrix that marks the topological distances between atoms
 
         static_args:
             dict: a dictionary that stores all static global parameters (such as lmax, kappa, etc)
@@ -73,7 +70,7 @@ def generate_pairwise_interaction(pair_int_kernel, covalent_map, static_args):
         rj = distribute_v3(positions, pairs[:, 1])
         # ri = positions[pairs[:, 0]]
         # rj = positions[pairs[:, 1]]
-        nbonds = covalent_map[pairs[:, 0], pairs[:, 1]]
+        nbonds = pairs[:, 3]
         mscales = distribute_scalar(mScales, nbonds-1)
 
         buffer_scales = pair_buffer_scales(pairs)

--- a/dmff/admp/pme.py
+++ b/dmff/admp/pme.py
@@ -304,7 +304,7 @@ def energy_pme(positions, box, pairs,
             (Nexcl,): multipole-multipole interaction exclusion scalings: 1-2, 1-3 ...
             for permanent-permanent, permanent-induced, induced-induced interactions
         pairs:
-            Np * 2: interacting pair indices
+            Np * 3: interacting pair indices and topology distance
         covalent_map:
             Na * Na: topological distances between atoms, if i, j are topologically distant, then covalent_map[i, j] == 0
         construct_local_frame_fn:
@@ -761,7 +761,7 @@ def pme_real(positions, box, pairs,
         box:
             3 * 3: box, axes arranged in row
         pairs:
-            Np * 2: interacting pair indices
+            Np * 3: interacting pair indices and topology distance
         Q_global:
             Na * (l+1)**2: harmonics multipoles of each atom, in global frame
         Uind_global:

--- a/dmff/api.py
+++ b/dmff/api.py
@@ -154,7 +154,7 @@ class ADMPDispGenerator:
             map_atomtype[i] = np.where(self.atomTypes == atype)[0][0]
         self.map_atomtype = map_atomtype
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
         # here box is only used to setup ewald parameters, no need to be differentiable
         a, b, c = system.getDefaultPeriodicBoxVectors()
         box = jnp.array([a._value, b._value, c._value]) * 10
@@ -166,7 +166,6 @@ class ADMPDispGenerator:
             self.ethresh = args["ethresh"]
 
         Force_DispPME = ADMPDispPmeForce(box,
-                                         covalent_map,
                                          rc,
                                          self.ethresh,
                                          self.pmax,
@@ -174,7 +173,6 @@ class ADMPDispGenerator:
         self.disp_pme_force = Force_DispPME
         pot_fn_lr = Force_DispPME.get_energy
         pot_fn_sr = generate_pairwise_interaction(TT_damping_qq_c6_kernel,
-                                                  covalent_map,
                                                   static_args={})
 
         def potential_fn(positions, box, pairs, params):
@@ -294,7 +292,7 @@ class ADMPDispPmeGenerator:
         self.map_atomtype = map_atomtype
 
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
 
         # here box is only used to setup ewald parameters, no need to be differentiable
         a, b, c = system.getDefaultPeriodicBoxVectors()
@@ -306,7 +304,7 @@ class ADMPDispPmeGenerator:
         if "ethresh" in args:
             self.ethresh = args["ethresh"]
 
-        disp_force = ADMPDispPmeForce(box, covalent_map, rc, self.ethresh,
+        disp_force = ADMPDispPmeForce(box, rc, self.ethresh,
                                       self.pmax, self.lpme)
         self.disp_force = disp_force
         pot_fn_lr = disp_force.get_energy
@@ -389,10 +387,9 @@ class QqTtDampingGenerator:
         self.map_atomtype = map_atomtype
 
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
 
         pot_fn_sr = generate_pairwise_interaction(TT_damping_qq_kernel,
-                                                  covalent_map,
                                                   static_args={})
 
         def potential_fn(positions, box, pairs, params):
@@ -475,11 +472,10 @@ class SlaterDampingGenerator:
             map_atomtype[i] = np.where(self.atomTypes == atype)[0][0]
         self.map_atomtype = map_atomtype
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
 
         # WORKING
         pot_fn_sr = generate_pairwise_interaction(slater_disp_damping_kernel,
-                                                  covalent_map,
                                                   static_args={})
 
         def potential_fn(positions, box, pairs, params):
@@ -559,10 +555,9 @@ class SlaterExGenerator:
             map_atomtype[i] = np.where(self.atomTypes == atype)[0][0]
         self.map_atomtype = map_atomtype
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
 
         pot_fn_sr = generate_pairwise_interaction(slater_sr_kernel,
-                                                  covalent_map,
                                                   static_args={})
 
         def potential_fn(positions, box, pairs, params):
@@ -834,7 +829,7 @@ class ADMPPmeGenerator:
         rc = nonbondedCutoff.value_in_unit(unit.angstrom)
 
         # build covalent map
-        covalent_map = build_covalent_map(data, 6)
+        self.covalent_map = covalent_map = build_covalent_map(data, 6)
 
         # build intra-molecule axis
         # the following code is the direct transplant of forcefield.py in openmm 7.4.0
@@ -1048,7 +1043,7 @@ class ADMPPmeGenerator:
             self.step_pol = args["step_pol"]
 
         pme_force = ADMPPmeForce(box, self.axis_types, self.axis_indices,
-                                 covalent_map, rc, self.ethresh, self.lmax,
+                                 rc, self.ethresh, self.lmax,
                                  self.lpol, self.lpme, self.step_pol)
         self.pme_force = pme_force
 
@@ -1719,7 +1714,7 @@ class NonbondedJaxGenerator:
         map_nbfix = []
         map_nbfix = np.array(map_nbfix, dtype=int).reshape((-1, 2))
 
-        colv_map = build_covalent_map(data, 6)
+        self.covalent_map = build_covalent_map(data, 6)
 
         if unit.is_quantity(nonbondedCutoff):
             r_cut = nonbondedCutoff.value_in_unit(unit.nanometer)
@@ -1778,7 +1773,6 @@ class NonbondedJaxGenerator:
                                         r_cut,
                                         map_lj,
                                         map_nbfix,
-                                        colv_map,
                                         isSwitch=ifSwitch,
                                         isPBC=ifPBC,
                                         isNoCut=isNoCut)
@@ -1787,7 +1781,6 @@ class NonbondedJaxGenerator:
                                                   r_cut,
                                                   map_lj,
                                                   map_nbfix,
-                                                  colv_map,
                                                   isSwitch=ifSwitch,
                                                   isPBC=ifPBC,
                                                   isNoCut=isNoCut,
@@ -1819,7 +1812,7 @@ class NonbondedJaxGenerator:
             assert np.sum(countMat) == len(map_lj) * (len(map_lj) - 1) // 2
 
             colv_pairs = np.argwhere(
-                np.logical_and(colv_map > 0, colv_map <= 3))
+                np.logical_and(self.covalent_map > 0, self.covalent_map <= 3))
             for pair in colv_pairs:
                 if pair[0] <= pair[1]:
                     tmp = (map_lj[pair[0]], map_lj[pair[1]])
@@ -1844,19 +1837,17 @@ class NonbondedJaxGenerator:
                     # use Reaction Field
                     coulforce = CoulReactionFieldForce(r_cut,
                                                        map_charge,
-                                                       colv_map,
                                                        isPBC=ifPBC)
                 if nonbondedMethod is app.NoCutoff:
                     # use NoCutoff
-                    coulforce = CoulNoCutoffForce(map_charge, colv_map)
+                    coulforce = CoulNoCutoffForce(map_charge)
             else:
-                coulforce = CoulombPMEForce(r_cut, map_charge, colv_map, kappa,
+                coulforce = CoulombPMEForce(r_cut, map_charge, kappa,
                                             (K1, K2, K3))
         else:
             assert nonbondedMethod is app.PME, "Only PME is supported in free energy calculations"
             coulforce = CoulombPMEFreeEnergyForce(r_cut,
                                                   map_charge,
-                                                  colv_map,
                                                   kappa, (K1, K2, K3),
                                                   coulLambda,
                                                   ifStateA=ifStateA,

--- a/dmff/classical/inter.py
+++ b/dmff/classical/inter.py
@@ -21,7 +21,6 @@ class LennardJonesForce:
         r_cut,
         map_prm,
         map_nbfix,
-        colvmap,
         isSwitch: bool = False,
         isPBC: bool = True,
         isNoCut: bool = False
@@ -34,7 +33,6 @@ class LennardJonesForce:
         self.map_nbfix = map_nbfix
         self.ifPBC = isPBC
         self.ifNoCut = isNoCut
-        self.colvmap = colvmap
 
     def generate_get_energy(self):
         def get_LJ_energy(dr_vec, sig, eps, box):
@@ -57,8 +55,8 @@ class LennardJonesForce:
 
         def get_energy(positions, box, pairs, epsilon, sigma, epsfix, sigfix, mscales):
             
-            pairs = regularize_pairs(pairs)
-            mask = pair_buffer_scales(pairs)
+            pairs = pairs.at[:, :2].set(regularize_pairs(pairs[:, :2]))
+            mask = pair_buffer_scales(pairs[:, :2])
             map_prm = self.map_prm
 
             eps_m1 = jnp.repeat(epsilon.reshape((-1, 1)), epsilon.shape[0], axis=1)
@@ -73,7 +71,7 @@ class LennardJonesForce:
             sig_mat = sig_mat.at[self.map_nbfix[:, 0], self.map_nbfix[:, 1]].set(sigfix)
             sig_mat = sig_mat.at[self.map_nbfix[:, 1], self.map_nbfix[:, 0]].set(sigfix)
 
-            colv_pair = self.colvmap[pairs[:,0],pairs[:,1]]
+            colv_pair = pairs[:, 2]
             mscale_pair = mscales[colv_pair-1] # in mscale vector, the 0th item is 1-2 scale, the 1st item is 1-3 scale, etc...
 
             dr_vec = positions[pairs[:, 0]] - positions[pairs[:, 1]]
@@ -132,11 +130,10 @@ class LennardJonesLongRangeForce:
 class CoulNoCutoffForce:
     # E=\frac{{q}_{1}{q}_{2}}{4\pi\epsilon_0\epsilon_1 r}
 
-    def __init__(self, map_prm, colvmap, epsilon_1=1.0) -> None:
+    def __init__(self, map_prm, epsilon_1=1.0) -> None:
 
         self.eps_1 = epsilon_1
         self.map_prm = map_prm
-        self.colvmap = colvmap
 
     def generate_get_energy(self):
         def get_coul_energy(dr_vec, chrgprod, box):
@@ -149,11 +146,11 @@ class CoulNoCutoffForce:
 
         def get_energy(positions, box, pairs, charges, mscales):
             
-            pairs = regularize_pairs(pairs)
-            mask = pair_buffer_scales(pairs)
+            pairs = pairs.at[:, :2].set(regularize_pairs(pairs[:, :2]))
+            mask = pair_buffer_scales(pairs[:, :2])
             map_prm = jnp.array(self.map_prm)
 
-            colv_pair = self.colvmap[pairs[:,0],pairs[:,1]]
+            colv_pair = pairs[:, 2]
             mscale_pair = mscales[colv_pair-1]
 
             chrg_map0 = map_prm[pairs[:, 0]]
@@ -177,7 +174,6 @@ class CoulReactionFieldForce:
         self,
         r_cut,
         map_prm,
-        colvmap,
         epsilon_1=1.0,
         epsilon_solv=78.5,
         isPBC=True,
@@ -189,7 +185,6 @@ class CoulReactionFieldForce:
         self.exp_solv = epsilon_solv
         self.eps_1 = epsilon_1
         self.map_prm = map_prm
-        self.colvmap = colvmap
         self.ifPBC = isPBC
 
     def generate_get_energy(self):
@@ -210,10 +205,10 @@ class CoulReactionFieldForce:
 
         def get_energy(positions, box, pairs, charges, mscales):
             
-            pairs = regularize_pairs(pairs)
-            mask = pair_buffer_scales(pairs)
+            pairs = pairs.at[:, :2].set(regularize_pairs(pairs[:, :2]))
+            mask = pair_buffer_scales(pairs[:, :2])
 
-            colv_pair = self.colvmap[pairs[:,0],pairs[:,1]]
+            colv_pair = pairs[:, 2]
             mscale_pair = mscales[colv_pair-1]
 
             chrg_map0 = self.map_prm[pairs[:, 0]]
@@ -237,14 +232,12 @@ class CoulombPMEForce:
         self,
         r_cut: float,
         map_prm: Iterable[int],
-        cov_mat: np.ndarray,
         kappa: float,
         K: Tuple[int, int, int],
         pme_order: int = 6,
     ):
         self.r_cut = r_cut
         self.map_prm = map_prm
-        self.cov_mat = cov_mat
         self.lmax = 0
         self.kappa = kappa
         self.K1, self.K2, self.K3 = K[0], K[1], K[2]
@@ -280,7 +273,6 @@ class CoulombPMEForce:
                 mscales,
                 None,
                 None,
-                self.cov_mat,
                 None,
                 pme_recip_fn,
                 self.kappa / 10,

--- a/dmff/common/covalent_map.py
+++ b/dmff/common/covalent_map.py
@@ -1,1 +1,0 @@
-# TODO: wrapper of jax.experimental.sparse.BCOO

--- a/dmff/common/covalent_map.py
+++ b/dmff/common/covalent_map.py
@@ -1,0 +1,1 @@
+# TODO: wrapper of jax.experimental.sparse.BCOO

--- a/dmff/common/nblist.py
+++ b/dmff/common/nblist.py
@@ -7,7 +7,7 @@ from jax import jit
 
 class NeighborList:
     
-    def __init__(self, box, rc) -> None:
+    def __init__(self, box, rc, covalent_map) -> None:
         """ wrapper of jax_md.space_periodic_general and jax_md.partition.NeighborList
 
         Args:
@@ -16,6 +16,7 @@ class NeighborList:
         """
         self.box = box
         self.rc = rc
+        self.covalent_map = covalent_map
         self.displacement_fn, self.shift_fn = space.periodic_general(box, fractional_coordinates=False)
         self.neighborlist_fn = partition.neighbor_list(self.displacement_fn, box, rc, 0, format=partition.OrderedSparse)
         self.nblist = None
@@ -54,7 +55,11 @@ class NeighborList:
         Returns:
             jnp.ndarray: (nPairs, 2)
         """
-        return self.nblist.idx.T
+        if self.nblist is None:
+            raise RuntimeError('run nblist.allocate(positions) first')
+        pairs = self.nblist.idx.T
+        nbond = self.covalent_map[pairs[:, 0], pairs[:, 1]]
+        return jnp.concatenate([pairs, nbond[:, None]], axis=1)
     
     @property
     def pair_mask(self):
@@ -64,9 +69,9 @@ class NeighborList:
             (jnp.ndarray, jnp.ndarray): ((nParis, 2), (nPairs, ))
         """
 
-        mask = jnp.sum(self.pairs == len(self.positions), axis=1)
+        mask = jnp.sum(self.pairs[:, :2] == len(self.positions), axis=1)
         mask = jnp.logical_not(mask)
-        pair = regularize_pairs(self.pairs)
+        pair = regularize_pairs(self.pairs[:, :2])
         
         return pair, mask
     

--- a/dmff/common/nblist.py
+++ b/dmff/common/nblist.py
@@ -44,11 +44,7 @@ class NeighborList:
         Returns:
             jax_md.partition.NeighborList
         """
-        # jit_deco = jit_condition()
-        # jit_deco(self.nblist.update)(positions)
         self.nblist = self.nblist.update(positions)
-        if self.nblist.did_buffer_overflow:
-            self.nblist = self.neighborlist_fn.allocate(positions)
         return self.nblist
     
     @property
@@ -102,3 +98,14 @@ class NeighborList:
         
         """
         return jnp.linalg.norm(self.dr, axis=1)
+
+    @property
+    def did_buffer_overflow(self)->bool:
+        """
+        if the neighborlist buffer overflowed, return True
+
+        Returns
+        -------
+        boolen
+        """
+        return self.nblist.did_buffer_overflow

--- a/tests/test_admp/test_compute.py
+++ b/tests/test_admp/test_compute.py
@@ -38,11 +38,13 @@ class TestADMPAPI:
         a, b, c = pdb.topology.getPeriodicBoxVectors()
         box = np.array([a._value, b._value, c._value]) * 10
         # neighbor list
-        nblist = NeighborList(box, rc)
-        nblist.allocate(positions)
-        pairs = nblist.pairs
         
         gen = generators[1]
+        covalent_map = gen.covalent_map
+
+        nblist = NeighborList(box, rc, covalent_map)
+        nblist.allocate(positions)
+        pairs = nblist.pairs
         pot = gen.getJaxPotential()
         energy = pot(positions, box, pairs, gen.paramtree)
 
@@ -55,12 +57,13 @@ class TestADMPAPI:
         positions = jnp.array(pdb.positions._value) * 10
         a, b, c = pdb.topology.getPeriodicBoxVectors()
         box = jnp.array([a._value, b._value, c._value]) * 10
+        gen = generators[1]
+        covalent_map = gen.covalent_map
         # neighbor list
-        nblist = NeighborList(box, rc)
+        nblist = NeighborList(box, rc, covalent_map)
         nblist.allocate(positions)
         pairs = nblist.pairs
 
-        gen = generators[1]
         pot = gen.getJaxPotential()
         j_pot_pme = jit(value_and_grad(pot))
         energy = j_pot_pme(positions, box, pairs, gen.paramtree)

--- a/tests/test_classical/test_coul.py
+++ b/tests/test_classical/test_coul.py
@@ -22,8 +22,13 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = np.array([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
-                         dtype=int)
+        # pairs = np.array([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
+        #                  dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         coulE = potential.getPotentialFunc(names="NonbondedForce")
         energy = coulE(pos, box, pairs, h.paramtree)
         npt.assert_almost_equal(energy, value, decimal=3)
@@ -43,11 +48,16 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = []
-        for ii in range(10):
-            for jj in range(ii + 1, 10):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(10):
+        #     for jj in range(ii + 1, 10):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         coulE = potential.getPotentialFunc()
         energy = coulE(pos, box, pairs, h.paramtree)
         npt.assert_almost_equal(energy, value, decimal=3)
@@ -67,11 +77,16 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = []
-        for ii in range(10):
-            for jj in range(ii + 1, 10):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(10):
+        #     for jj in range(ii + 1, 10):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         coulE = potential.getPotentialFunc()
         energy = coulE(pos, box, pairs, h.paramtree)
         npt.assert_almost_equal(energy, value, decimal=3)
@@ -112,7 +127,10 @@ class TestCoulomb:
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
         ], dtype=jnp.float64)
-        nbList = NeighborList(box, rc=rcut)
+
+        gen = h.getGenerators()[-1]
+
+        nbList = NeighborList(box, rcut, gen.covalent_map)
         nbList.allocate(positions)
         pairs = nbList.pairs
         func = potential.getPotentialFunc(names=["NonbondedForce"])

--- a/tests/test_classical/test_coul.py
+++ b/tests/test_classical/test_coul.py
@@ -22,8 +22,6 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = np.array([[0, 1], [0, 2], [0, 3], [1, 2], [1, 3], [2, 3]],
-        #                  dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)
@@ -48,11 +46,6 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = []
-        # for ii in range(10):
-        #     for jj in range(ii + 1, 10):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)
@@ -77,11 +70,6 @@ class TestCoulomb:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = []
-        # for ii in range(10):
-        #     for jj in range(ii + 1, 10):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)
@@ -126,7 +114,7 @@ class TestCoulomb:
             [ 1.20,  0.00,  0.00],
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
-        ], dtype=jnp.float64)
+        ])
 
         gen = h.getGenerators()[-1]
 

--- a/tests/test_classical/test_fep.py
+++ b/tests/test_classical/test_fep.py
@@ -47,7 +47,8 @@ class TestFreeEnergy:
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
         ], dtype=jnp.float64)
-        nbList = NeighborList(box, rc=rcut)
+        gen = h.getGenerators()[-1]
+        nbList = NeighborList(box, rcut, gen.covalent_map)
         nbList.allocate(positions)
         pairs = nbList.pairs
         func = jax.value_and_grad(potential.dmff_potentials["NonbondedForce"], argnums=-1)
@@ -102,7 +103,8 @@ class TestFreeEnergy:
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
         ], dtype=jnp.float64)
-        nbList = NeighborList(box, rc=rcut)
+        gen = h.getGenerators()[-1]
+        nbList = NeighborList(box, rcut, gen.covalent_map)
         nbList.allocate(positions)
         pairs = nbList.pairs
         func = jax.value_and_grad(potential.dmff_potentials["NonbondedForce"], argnums=-2)

--- a/tests/test_classical/test_fep.py
+++ b/tests/test_classical/test_fep.py
@@ -46,7 +46,7 @@ class TestFreeEnergy:
             [ 1.20,  0.00,  0.00],
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
-        ], dtype=jnp.float64)
+        ])
         gen = h.getGenerators()[-1]
         nbList = NeighborList(box, rcut, gen.covalent_map)
         nbList.allocate(positions)
@@ -102,7 +102,7 @@ class TestFreeEnergy:
             [ 1.20,  0.00,  0.00],
             [ 0.00,  1.20,  0.00],
             [ 0.00,  0.00,  1.20]
-        ], dtype=jnp.float64)
+        ])
         gen = h.getGenerators()[-1]
         nbList = NeighborList(box, rcut, gen.covalent_map)
         nbList.allocate(positions)

--- a/tests/test_classical/test_gaff2.py
+++ b/tests/test_classical/test_gaff2.py
@@ -5,7 +5,7 @@ import openmm.app as app
 import openmm.unit as unit
 import numpy as np
 import numpy.testing as npt
-from dmff.api import Hamiltonian
+from dmff import Hamiltonian, NeighborList
 
 
 class TestGaff2:
@@ -23,11 +23,16 @@ class TestGaff2:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = []
-        for ii in range(pos.shape[0]):
-            for jj in range(ii + 1, pos.shape[0]):
-                pairs.append((ii, jj))
-        pairs = jnp.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(pos.shape[0]):
+        #     for jj in range(ii + 1, pos.shape[0]):
+        #         pairs.append((ii, jj))
+        # pairs = jnp.array(pairs, dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         ljE = potential.getPotentialFunc()
         energy = ljE(pos, box, pairs, h.paramtree)
         npt.assert_almost_equal(energy, value, decimal=3)
@@ -60,11 +65,16 @@ class TestGaff2:
         )
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]])
-        pairs = []
-        for ii in range(pos.shape[0]):
-            for jj in range(ii + 1, pos.shape[0]):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(pos.shape[0]):
+        #     for jj in range(ii + 1, pos.shape[0]):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         for ne, energy in enumerate(potential.dmff_potentials.values()):
             E = energy(pos, box, pairs, h.paramtree)
             npt.assert_almost_equal(E, values[ne], decimal=3)
@@ -97,11 +107,16 @@ class TestGaff2:
         )
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]])
-        pairs = []
-        for ii in range(pos.shape[0]):
-            for jj in range(ii + 1, pos.shape[0]):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(pos.shape[0]):
+        #     for jj in range(ii + 1, pos.shape[0]):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)
+        rc = 4
+        gen = h.getGenerators()[-1]
+        nblist = NeighborList(box, rc, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         efunc = potential.getPotentialFunc()
         Eref = sum(values)
         Ecalc = efunc(pos, box, pairs, h.paramtree)

--- a/tests/test_classical/test_gaff2.py
+++ b/tests/test_classical/test_gaff2.py
@@ -23,11 +23,6 @@ class TestGaff2:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = []
-        # for ii in range(pos.shape[0]):
-        #     for jj in range(ii + 1, pos.shape[0]):
-        #         pairs.append((ii, jj))
-        # pairs = jnp.array(pairs, dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)
@@ -65,11 +60,6 @@ class TestGaff2:
         )
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]])
-        # pairs = []
-        # for ii in range(pos.shape[0]):
-        #     for jj in range(ii + 1, pos.shape[0]):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)
@@ -107,11 +97,6 @@ class TestGaff2:
         )
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[20.0, 0.0, 0.0], [0.0, 20.0, 0.0], [0.0, 0.0, 20.0]])
-        # pairs = []
-        # for ii in range(pos.shape[0]):
-        #     for jj in range(ii + 1, pos.shape[0]):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)
         rc = 4
         gen = h.getGenerators()[-1]
         nblist = NeighborList(box, rc, gen.covalent_map)

--- a/tests/test_classical/test_lj.py
+++ b/tests/test_classical/test_lj.py
@@ -47,11 +47,6 @@ class TestVdW:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = []
-        # for ii in range(10):
-        #     for jj in range(ii + 1, 10):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)
         gen = h.getGenerators()[0]
         nblist = NeighborList(box, 4.0, gen.covalent_map)
         nblist.allocate(pos)
@@ -71,12 +66,7 @@ class TestVdW:
                                    constraints=None,
                                    removeCMMotion=False)
         pos = pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer)
-        box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        # pairs = []
-        # for ii in range(10):
-        #     for jj in range(ii + 1, 10):
-        #         pairs.append((ii, jj))
-        # pairs = np.array(pairs, dtype=int)     
+        box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])     
         gen = h.getGenerators()[0]
         nblist = NeighborList(box, 4.0, gen.covalent_map)
         nblist.allocate(pos)              

--- a/tests/test_classical/test_lj.py
+++ b/tests/test_classical/test_lj.py
@@ -21,9 +21,10 @@ class TestVdW:
                                    nonbondedMethod=app.NoCutoff,
                                    constraints=None,
                                    removeCMMotion=False)
+        gen = h.getGenerators()[0]
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = jnp.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        nblist = NeighborList(box, 4.0)
+        nblist = NeighborList(box, 4.0, gen.covalent_map)
         nblist.allocate(pos)
         pairs = nblist.pairs
         ljE = potential.getPotentialFunc()
@@ -46,11 +47,15 @@ class TestVdW:
                                    removeCMMotion=False)
         pos = jnp.asarray(pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer))
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = []
-        for ii in range(10):
-            for jj in range(ii + 1, 10):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)
+        # pairs = []
+        # for ii in range(10):
+        #     for jj in range(ii + 1, 10):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)
+        gen = h.getGenerators()[0]
+        nblist = NeighborList(box, 4.0, gen.covalent_map)
+        nblist.allocate(pos)
+        pairs = nblist.pairs
         ljE = potential.getPotentialFunc()
         energy = ljE(pos, box, pairs, h.paramtree)
         npt.assert_almost_equal(energy, value, decimal=3)
@@ -67,11 +72,15 @@ class TestVdW:
                                    removeCMMotion=False)
         pos = pdb.getPositions(asNumpy=True).value_in_unit(unit.nanometer)
         box = np.array([[10.0, 0.0, 0.0], [0.0, 10.0, 0.0], [0.0, 0.0, 10.0]])
-        pairs = []
-        for ii in range(10):
-            for jj in range(ii + 1, 10):
-                pairs.append((ii, jj))
-        pairs = np.array(pairs, dtype=int)                                        
+        # pairs = []
+        # for ii in range(10):
+        #     for jj in range(ii + 1, 10):
+        #         pairs.append((ii, jj))
+        # pairs = np.array(pairs, dtype=int)     
+        gen = h.getGenerators()[0]
+        nblist = NeighborList(box, 4.0, gen.covalent_map)
+        nblist.allocate(pos)              
+        pairs = nblist.pairs 
         ljE = potential.getPotentialFunc()
         with pytest.raises(TypeError):
             energy = ljE(pos, box, pairs, h.getGenerators()[0].paramtree)

--- a/tests/test_common/test_nblist.py
+++ b/tests/test_common/test_nblist.py
@@ -2,26 +2,40 @@ import pytest
 import jax.numpy as jnp
 from jax import jit
 from dmff import NeighborList
-from dmff.utils import jit_condition
+import openmm.app as app
+import openmm.unit as unit
+import numpy as np
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+from dmff import Hamiltonian, NeighborList
 
 class TestNeighborList:
     
     @pytest.fixture(scope="class", name='nblist')
     def test_nblist_init(self):
-        positions = jnp.array([
-            [12.434,   3.404,   1.540],
-            [13.030,   2.664,   1.322],
-            [12.312,   3.814,   0.660],
-            [14.216,   1.424,   1.103],
-            [14.246,   1.144,   2.054],
-            [15.155,   1.542,   0.910]
-        ])
-        box = jnp.array([31.289,   31.289,   31.289])
-        r_cutoff = 4.0
-        nbobj = NeighborList(box, r_cutoff)
+
+        """load generators from XML file
+
+        Yields:
+            Tuple: (
+                ADMPDispForce,
+                ADMPPmeForce, # polarized
+            )
+        """
+        rc = 4.0
+        H = Hamiltonian('tests/data/admp.xml')
+        pdb = app.PDBFile('tests/data/water_dimer.pdb')
+        potential = H.createPotential(pdb.topology, nonbondedCutoff=rc*unit.angstrom, ethresh=5e-4, step_pol=5)
+        generators = H.getGenerators()
+        a, b, c = pdb.topology.getPeriodicBoxVectors()
+        box = np.array([a._value, b._value, c._value]) * 10
+        positions = np.array(pdb.positions._value) * 10
+
+
+        nbobj = NeighborList(box, rc, generators[1].covalent_map)
         nbobj.allocate(positions)
         yield nbobj
-        
 
 
     def test_update(self, nblist):
@@ -39,7 +53,7 @@ class TestNeighborList:
     def test_pairs(self, nblist):
         
         pairs = nblist.pairs
-        assert pairs.shape == (15, 2)
+        assert pairs.shape == (15, 3)
         
     def test_pair_mask(self, nblist):
         

--- a/tests/test_common/test_nblist.py
+++ b/tests/test_common/test_nblist.py
@@ -22,19 +22,6 @@ class TestNeighborList:
         nbobj.allocate(positions)
         yield nbobj
         
-    def test_jit_update(self, nblist):
-
-        positions = jnp.array([
-            [12.434,   3.404,   1.540],
-            [13.030,   2.664,   1.322],
-            [12.312,   3.814,   0.660],
-            [14.216,   1.424,   1.103],
-            [14.246,   1.144,   2.054],
-            [15.155,   1.542,   0.910]
-        ])   
-
-        jit(nblist.update)(positions) # pass 
-        jit(nblist.update)(positions) # pass 
 
 
     def test_update(self, nblist):
@@ -67,3 +54,17 @@ class TestNeighborList:
     def test_distance(self, nblist):
         
         assert nblist.distance.shape == (15, )
+
+    def test_jit_update(self, nblist):
+
+        positions = jnp.array([
+            [12.434,   3.404,   1.540],
+            [13.030,   2.664,   1.322],
+            [12.312,   3.814,   0.660],
+            [14.216,   1.424,   1.103],
+            [14.246,   1.144,   2.054],
+            [15.155,   1.542,   0.910]
+        ])   
+
+        jit(nblist.update)(positions) # pass 
+        jit(nblist.update)(positions) # pass 

--- a/tests/test_common/test_nblist.py
+++ b/tests/test_common/test_nblist.py
@@ -1,8 +1,8 @@
 import pytest
 import jax.numpy as jnp
-
+from jax import jit
 from dmff import NeighborList
-
+from dmff.utils import jit_condition
 
 class TestNeighborList:
     
@@ -22,6 +22,21 @@ class TestNeighborList:
         nbobj.allocate(positions)
         yield nbobj
         
+    def test_jit_update(self, nblist):
+
+        positions = jnp.array([
+            [12.434,   3.404,   1.540],
+            [13.030,   2.664,   1.322],
+            [12.312,   3.814,   0.660],
+            [14.216,   1.424,   1.103],
+            [14.246,   1.144,   2.054],
+            [15.155,   1.542,   0.910]
+        ])   
+
+        jit(nblist.update)(positions) # pass 
+        jit(nblist.update)(positions) # pass 
+
+
     def test_update(self, nblist):
 
         positions = jnp.array([


### PR DESCRIPTION
Refactor `covalent_map` and `pairs` argument. 
Detail:
Now `covalent_map` is merged to `NeighborList` class, and `nblist.pairs` not return a `(N, 3)` array, which new column equivalent to previous `covalent_map[pairs[:, 0], pairs[:, 1]]`. 
All the calculators have been updated to the new format of `pairs,` and all tests pass. 