### PR TITLE
Bugs fix in BCC matching

### DIFF
--- a/dmff/classical/vsite.py
+++ b/dmff/classical/vsite.py
@@ -96,9 +96,9 @@ class VirtualSite:
             dummy = Chem.Atom(0)
             duIdx = rwmol.AddAtom(dummy)
             rwmol.AddBond(duIdx, pidx)
-            newmol = rwmol.GetMol()
             duIdxs.append(duIdx)
-
+        
+        newmol = rwmol.GetMol()
         if addCoords is not None:
             assert len(addCoords) == len(parentAtomIdx) + ori_num_atoms, f"Number of atoms in coordinates doesn't match"
             conf = newmol.GetConformer()

--- a/dmff/fftree.py
+++ b/dmff/fftree.py
@@ -371,9 +371,7 @@ class TypeMatcher:
                 assert len(match) == 2
                 if (match[1], match[0]) in matches_dict:
                     matches_dict.pop((match[1], match[0]))
-                    matches_dict.update({(match[1], match[0]): idx})
-                else:
-                    matches_dict.update({match: idx})
+                matches_dict.update({match: idx})
         
         return matches_dict
 

--- a/dmff/generators/classical.py
+++ b/dmff/generators/classical.py
@@ -683,6 +683,7 @@ class NonbondedJaxGenerator:
 
         
         rdmol = args.get("rdmol", None)
+        raiseBccMatchError = args.get("raiseBccMatchError", False)
 
         if self.useVsite:
             vsitematcher = TypeMatcher(self.fftree, "NonbondedForce/VirtualSite")
@@ -794,7 +795,7 @@ class NonbondedJaxGenerator:
                         self.top_mat[query2[1], nnode] -= 1
                     else:
                         msg = f"No BCC parameter for bond between Atom{beginAtomIdx} and Atom{endAtomIdx}" 
-                        if args.get("raiseBccMatchError", False):
+                        if raiseBccMatchError:
                             raise DMFFException(msg)
                         else:
                             warnings.warn(msg)

--- a/dmff/generators/classical.py
+++ b/dmff/generators/classical.py
@@ -793,9 +793,11 @@ class NonbondedJaxGenerator:
                         self.top_mat[query2[0], nnode] += 1
                         self.top_mat[query2[1], nnode] -= 1
                     else:
-                        warnings.warn(
-                            f"No BCC parameter for bond between Atom{beginAtomIdx} and Atom{endAtomIdx}"
-                        )
+                        msg = f"No BCC parameter for bond between Atom{beginAtomIdx} and Atom{endAtomIdx}" 
+                        if args.get("raiseBccMatchError", False):
+                            raise DMFFExecption(msg)
+                        else:
+                            warings.warn(msg)
             else:
                 raise DMFFException(
                     "Only SMIRKS-based parametrization is supported for BCC"

--- a/dmff/generators/classical.py
+++ b/dmff/generators/classical.py
@@ -795,9 +795,9 @@ class NonbondedJaxGenerator:
                     else:
                         msg = f"No BCC parameter for bond between Atom{beginAtomIdx} and Atom{endAtomIdx}" 
                         if args.get("raiseBccMatchError", False):
-                            raise DMFFExecption(msg)
+                            raise DMFFException(msg)
                         else:
-                            warings.warn(msg)
+                            warnings.warn(msg)
             else:
                 raise DMFFException(
                     "Only SMIRKS-based parametrization is supported for BCC"

--- a/tests/data/ethane_smirks.xml
+++ b/tests/data/ethane_smirks.xml
@@ -46,6 +46,6 @@
 		<Atom epsilon="0.0870272000" sigma="0.2600180000" smirks="[$([#1]-[#6X4]):1]"/>
 		<BondChargeCorrection smirks="[#6X4:1]-[#6X4:2]" bcc="0.000" />
 		<BondChargeCorrection smirks="[#6:1]-[#1:2]" bcc="0.000" />
-		<BondChargeCorrection smirks="[#6X4:1]-[#1:2]" bcc="0.0393" />
+		<BondChargeCorrection smirks="[#1:2]-[#6X4:1]" bcc="-0.0393" />
 	</NonbondedForce>
 </ForceField>


### PR DESCRIPTION
1. Fix possible undefined variables error in adding vsite to rdkit.Mol object
2. Fix bcc wrong matching order