### PR TITLE
Add docker image for building the OpenMM Plugin for DMFF

### DIFF
--- a/backend/openmm_dmff_plugin/python/CMakeLists.txt
+++ b/backend/openmm_dmff_plugin/python/CMakeLists.txt
@@ -22,6 +22,12 @@ execute_process(
     OUTPUT_VARIABLE GIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+execute_process(
+    COMMAND git describe --tags
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    OUTPUT_VARIABLE GIT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
 # Compile the Python module.
 add_custom_target(PythonInstall DEPENDS "${WRAP_FILE}")
@@ -36,4 +42,3 @@ add_custom_command(TARGET PythonInstall
     COMMAND "${PYTHON_EXECUTABLE}" setup.py install
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
-

--- a/backend/openmm_dmff_plugin/python/CMakeLists.txt
+++ b/backend/openmm_dmff_plugin/python/CMakeLists.txt
@@ -23,7 +23,7 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 execute_process(
-    COMMAND git describe --tags
+    COMMAND git describe --tags --abbrev=0
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     OUTPUT_VARIABLE GIT_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/backend/openmm_dmff_plugin/python/setup.py
+++ b/backend/openmm_dmff_plugin/python/setup.py
@@ -33,7 +33,7 @@ extension = Extension(name='OpenMMDMFFPlugin._OpenMMDMFFPlugin',
 
 
 setup(name='OpenMMDMFFPlugin',
-      version="@GIT_HASH@",
+      version="@GIT_VERSION@".lstrip('v').replace('-', ''),
       ext_modules=[extension],
       packages=['OpenMMDMFFPlugin', "OpenMMDMFFPlugin.tests"],
       package_data={"OpenMMDMFFPlugin":['data/lj_fluid/*.pb', 'data/lj_fluid/variables/variables.index', 'data/lj_fluid/variables/variables.data-00000-of-00001', 'data/lj_fluid_gpu/*.pb', 'data/lj_fluid_gpu/variables/variables.index', 'data/lj_fluid_gpu/variables/variables.data-00000-of-00001', 'data/*.pdb']},

--- a/package/docker/develop_gpu.dockerfile
+++ b/package/docker/develop_gpu.dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:22.04
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get install -y wget cmake git g++
+
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda && \
+    /opt/miniconda/bin/conda init bash && \
+    rm -rf Miniconda3-latest-Linux-x86_64.sh
+
+RUN eval "$(/opt/miniconda/bin/conda shell.bash hook)" && \
+	export CONDA_OVERRIDE_CUDA="12.0" && \
+	conda create -y -n dmff_omm -c conda-forge python=3.11 openmm libtensorflow_cc tensorflow-gpu swig numpy && \
+	conda activate dmff_omm && \
+	TF_VERSION=$(python -c 'import tensorflow as tf; print(tf.__version__)') && \
+	wget https://github.com/tensorflow/tensorflow/archive/refs/tags/v$TF_VERSION.tar.gz && \
+	tar -xf v$TF_VERSION.tar.gz && \
+	mkdir -p ${CONDA_PREFIX}/include/tensorflow/c && \
+	cp -r tensorflow-$TF_VERSION/tensorflow/c ${CONDA_PREFIX}/include/tensorflow && \
+	rm -r tensorflow-$TF_VERSION v$TF_VERSION.tar.gz
+
+# install TF C API for cppflow: https://www.tensorflow.org/install/lang_c
+# wget https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-$TF_VERSION.tar.gz
+# tar -xf libtensorflow-gpu-linux-x86_64-$TF_VERSION.tar.gz -C /usr/local
+
+RUN eval "$(/opt/miniconda/bin/conda shell.bash hook)" && \
+	conda activate dmff_omm && \
+	git clone https://github.com/caic99/DMFF.git && \
+	git clone https://github.com/serizba/cppflow.git && \
+		cd cppflow && \
+		git apply ../DMFF/backend/openmm_dmff_plugin/tests/cppflow_empty_constructor.patch && \
+		cp -r include/cppflow ${CONDA_PREFIX}/include && \
+		cd .. && \
+		rm -r cppflow && \
+	export OPENMM_INSTALLED_DIR=$CONDA_PREFIX && \
+	export CPPFLOW_INSTALLED_DIR=$CONDA_PREFIX && \
+	export LIBTENSORFLOW_INSTALLED_DIR=$CONDA_PREFIX && \
+	cd DMFF/backend/openmm_dmff_plugin/ && \
+	mkdir build && cd build && \
+	cmake .. -DOPENMM_DIR=${OPENMM_INSTALLED_DIR} \
+		-DCPPFLOW_DIR=${CPPFLOW_INSTALLED_DIR} \
+		-DTENSORFLOW_DIR=${LIBTENSORFLOW_INSTALLED_DIR} && \
+	make -j && make install && \
+	make -j PythonInstall && \
+	cd / && rm -r DMFF
+	# python -m OpenMMDMFFPlugin.tests.test_dmff_plugin_nve -n 100 && \


### PR DESCRIPTION
> 3. Test the plugin in Python interface, reference platform.
   ```shell
   python -m OpenMMDMFFPlugin.tests.test_dmff_plugin_nve -n 100
   python -m OpenMMDMFFPlugin.tests.test_dmff_plugin_nvt -n 100 --platform CUDA
   ```
These commands does not work.

And there are deprecation notices from `setuptools`:
> setup.py install is deprecated.
easy_install command is deprecated.