### PR TITLE
docs: add easy installation

### DIFF
--- a/docs/user_guide/2.installation.md
+++ b/docs/user_guide/2.installation.md
@@ -1,5 +1,19 @@
 # 2. Installation
-## 2.1 Install Dependencies
+## 2.1 Easy installation
+
+[![conda-forge](https://img.shields.io/conda/dn/conda-forge/dmff?color=red&label=conda-forge&logo=conda-forge)](https://anaconda.org/conda-forge/dmff)
+
+You can [setup a conda environment](https://docs.deepmodeling.com/faq/conda.html), and then use conda to install DMFF from conda-forge:
+
+```sh
+conda create -n dmff dmff -c conda-forge
+conda activate dmff
+```
+
+## 2.2 Install DMFF from Source Code
+
+Alternatively, you can install DMFF from the source. Firstly, install its dependencies:
+
 + Create conda environment:
 ```
 conda create -n dmff python=3.9 --yes
@@ -31,7 +45,7 @@ conda install -c conda-forge openmm==7.7.0
 ```bash
 conda install -c conda-forge rdkit
 ```
-## 2.2 Install DMFF from Source Code
+
 One can download the DMFF source code from github and install it using `pip`. :
 ```bash
 git clone https://github.com/deepmodeling/DMFF.git


### PR DESCRIPTION
This should fix #164, where conda will install packages with consistent CUDA versions.