### PR TITLE
add methods for QEq

### DIFF
--- a/dmff/admp/qeq.py
+++ b/dmff/admp/qeq.py
@@ -1,6 +1,7 @@
 import numpy as np
 import jax.numpy as jnp
-from ..common.constants import DIELECTRIC
+from scipy import constants
+from ..common.constants import DIELECTRIC, ENERGY_COEFF
 from jax import grad, vmap
 from ..classical.inter import CoulNoCutoffForce, CoulombPMEForce
 from typing import Tuple, List
@@ -126,13 +127,13 @@ def E_site(chi, J, q):
 
 @jit_condition()
 def E_site2(chi, J, q):
-    ene = (chi * q + 0.5 * J * q**2) * 96.4869
+    ene = (chi * q + 0.5 * J * q**2) * ENERGY_COEFF
     return jnp.sum(ene)
 
 
 @jit_condition()
 def E_site3(chi, J, q):
-    ene = chi * q * 4.184 + J * q**2 * DIELECTRIC * 2 * jnp.pi
+    ene = chi * q * constants.calorie + J * q**2 * DIELECTRIC * 2 * jnp.pi
     return jnp.sum(ene)
 
 

--- a/dmff/common/constants.py
+++ b/dmff/common/constants.py
@@ -1,4 +1,14 @@
 import numpy as np
+from scipy import constants
 
-DIELECTRIC = 1389.35455846
+
 SQRT_PI = np.sqrt(np.pi)
+
+J2EV = constants.physical_constants["joule-electron volt relationship"][0]
+# from kJ/mol to eV/particle
+ENERGY_COEFF = J2EV * constants.kilo / constants.Avogadro
+
+# vacuum electric permittivity in eV^-1 * angstrom^-1
+EPSILON = constants.epsilon_0 / constants.elementary_charge * constants.angstrom
+# DIELECTRIC = 1389.35455846
+DIELECTRIC = 1 / (4 * np.pi * EPSILON) / ENERGY_COEFF

--- a/dmff/generators/qeq.py
+++ b/dmff/generators/qeq.py
@@ -177,7 +177,7 @@ class ADMPQeqGenerator:
             has_aux = kwargs["has_aux"]
 
         method = kwargs.get("method", "root_finding")
-        
+        pgrad_kwargs = kwargs.get("pgrad_kwargs", {})
         qeq_force = ADMPQeqForce(
             init_q,
             r_cut,
@@ -192,6 +192,7 @@ class ADMPQeqGenerator:
             pbc_flag=(not isNoCut),
             has_aux=has_aux,
             method=method,
+            pgrad_kwargs=pgrad_kwargs,
         )
         qeq_energy = qeq_force.generate_get_energy()
 

--- a/dmff/generators/qeq.py
+++ b/dmff/generators/qeq.py
@@ -176,6 +176,8 @@ class ADMPQeqGenerator:
         if "has_aux" in kwargs:
             has_aux = kwargs["has_aux"]
 
+        method = kwargs.get("method", "root_finding")
+        
         qeq_force = ADMPQeqForce(
             init_q,
             r_cut,
@@ -189,6 +191,7 @@ class ADMPQeqGenerator:
             constQ=constQ,
             pbc_flag=(not isNoCut),
             has_aux=has_aux,
+            method=method,
         )
         qeq_energy = qeq_force.generate_get_energy()
 


### PR DESCRIPTION
- add `method` in API for QEq 
- set the original method as `root_finding` (default) 
- add `mat_inv` (matrix inversion) and `pgrad` (projected gradient) method 