### PR TITLE
fix bug in ver requirements

### DIFF
--- a/.github/workflows/test_openmm_dmff_plugin.yml
+++ b/.github/workflows/test_openmm_dmff_plugin.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Dependencies
         run: |
           source $CONDA/bin/activate
-          conda create -n dmff_omm -y python=${{ matrix.python-version }} numpy openmm=7.7 -c conda-forge
+          conda create -n dmff_omm -y python=${{ matrix.python-version }} numpy=1.* openmm=7.7 -c conda-forge
           conda activate dmff_omm
           conda install -y libtensorflow_cc=2.9.1 -c conda-forge
           pip install setuptools==59.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.18
+numpy>=1.18, <2
 mkdocs>=1.3.0
 mkdocs-autorefs>=0.4.1
 mkdocs-gen-files>=0.3.4
@@ -6,7 +6,7 @@ mkdocs-literate-nav>=0.4.1
 mkdocstrings>=0.19.0
 mkdocstrings-python>=0.7.0
 pygments>=2.12
-jax>=0.4.1
+jax>=0.4.1, <=0.4.20
 jaxlib>=0.4.1
 pymbar>=4.0.0
 tqdm


### PR DESCRIPTION
- jax <=0.4.20 for `from jax.config import config` in `dmff.setting`
    - See https://github.com/jax-ml/jax/discussions/18403 for further update
- numpy < 2.0 for openmm plugin