### PR TITLE
Wrapper for torch Kernel

### DIFF
--- a/dmff/torch_tools.py
+++ b/dmff/torch_tools.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import numpy as np
+import jax.numpy as jnp
+import jax
+import torch
+from torch2jax import j2t, t2j
+from functools import partial
+
+
+def t2j_element(e):
+    if torch.is_tensor(e):
+        return t2j(e)
+    else:
+        return e
+
+def j2t_element(e):
+    if isinstance(e, jax.numpy.ndarray):
+        e = j2t(e)
+        e.requires_grad = True
+        return e
+    else:
+        return e
+
+def t2j_extract_grad(v):
+    # extract the gradient of a pytree composed by torch tensors
+    def t2j_extract_grad_element(x):
+        if torch.is_tensor(x) and x.grad is not None:
+            return t2j(x.grad)
+        else:
+            return t2j(torch.zeros(x.shape))
+    return jax.tree.map(t2j_extract_grad_element, v)
+
+
+def t2j_pytree(v):
+    return jax.tree.map(t2j_element, v)
+
+
+def j2t_pytree(v):
+    return jax.tree.map(j2t_element, v)
+
+
+def wrap_torch_potential_kernel(potential_t):
+
+    @partial(jax.custom_jvp,  nondiff_argnums=(2,))
+    def potential(positions, box, pairs, params):
+        res = potential_t(j2t_pytree(positions), \
+                          j2t_pytree(box), \
+                          np.array(pairs), \
+                          j2t_pytree(params))
+        return res
+
+    @potential.defjvp
+    def potential_jvp(pairs, primals, tangents):
+        positions, box, params = primals
+        dpositions, dbox, dparams = tangents
+        # convert inputs to torch
+        positions_t = j2t_pytree(positions)
+        box_t = j2t_pytree(box)
+        params_t = j2t_pytree(params)
+        # do fwd and bwd in torch
+        primal_out_torch = potential_t(positions_t, box_t, np.array(pairs), params_t)
+        primal_out_torch.backward()
+        # read gradient in torch
+        g_positions = t2j_extract_grad(positions_t)
+        g_box = t2j_extract_grad(box_t)
+        g_params = t2j_extract_grad(params_t)
+        # prepare output
+        primal_out = t2j(primal_out_torch)
+        tangent_out = jnp.sum(g_positions * dpositions) + jnp.sum(g_box * box)
+        tangents_leaves = jax.tree.leaves(dparams)
+        grad_leaves = jax.tree.leaves(g_params)
+        for x, y in zip(tangents_leaves, grad_leaves):
+            tangent_out += jnp.sum(x * y)
+        return primal_out, tangent_out
+
+    return potential
+
+

--- a/docs/user_guide/3.usage.md
+++ b/docs/user_guide/3.usage.md
@@ -115,3 +115,26 @@ print(pgrad["NonbondedForce"]["sigma"])
   0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00
   0.00000000e+00]
 ```
+
+### 3.4 Wrapping torch potential kernel
+
+Considering the popularity of pytorch, DMFF also provides a convenient wrapper to wrap a torch potential kernel into a DMFF potential function that is compatible with the JAX environment. It uses the [torch2jax](https://github.com/samuela/torch2jax)  package to convert between tensors and jax ndarrays, and the `custom_jvp` function in jax to call torch gradient function, so one does not need to rewrite a torch potential kernel using jax.
+
+Examples can be found in the `examples/torch_kernel` folder. And the basic usage is like below:
+
+```python
+from dmff.torch_tools import wrap_torch_potential_kernel
+
+def potential_t(positions, box, pairs, params):
+    # Suppose potential_t is a torch kernel, with positions and box being torch tensors
+    # and params is a multi-level dictionary with torch-tensor leaves
+    ...
+    return ene
+
+# Wrap it to make it compatible with jax environment
+potential_wrapped = wrap_torch_potential_kernel(potential_t)
+# then you can use it as a normal jax-based potential function, which can be fed to jax.grad
+ene, p_grad = jax.value_and_grad(potential_wrapped, argnums=3)(positions, box, nbl.pairs, params)
+
+```
+

--- a/docs/user_guide/3.usage.md
+++ b/docs/user_guide/3.usage.md
@@ -118,7 +118,7 @@ print(pgrad["NonbondedForce"]["sigma"])
 
 ### 3.4 Wrapping torch potential kernel
 
-Considering the popularity of pytorch, DMFF also provides a convenient wrapper to wrap a torch potential kernel into a DMFF potential function that is compatible with the JAX environment. It uses the [torch2jax](https://github.com/samuela/torch2jax)  package to convert between tensors and jax ndarrays, and the `custom_jvp` function in jax to call torch gradient function, so one does not need to rewrite a torch potential kernel using jax.
+Considering the popularity of pytorch, DMFF also provides a convenient wrapper to wrap a torch potential kernel into a DMFF potential function that is compatible with the JAX environment. It uses the [torch2jax](https://github.com/samuela/torch2jax)  package to convert between tensors and jax ndarrays, and the `custom_jvp` function in jax to call torch gradient function, so one does not need to rewrite a torch potential kernel using jax. It may not be the most efficient way, but should work for efficiency-insensitive scenarios.
 
 Examples can be found in the `examples/torch_kernel` folder. And the basic usage is like below:
 

--- a/examples/torch_kernel/config/freud.ini
+++ b/examples/torch_kernel/config/freud.ini
@@ -1,0 +1,40 @@
+
+[LAYOUT]
+# Width of sidebar that contains server names
+server_width = 15
+# Height of container that holds headers
+header_height = 10
+# Height of container that shows server summary
+summary_height = 10
+
+[KEYS]
+new_server = n
+edit_server = e
+send_request = r
+edit_authentication = a
+edit_headers = h
+edit_body = b
+delete_server = d
+open_response_body = o
+sort_servers = s
+key_quick_ref = c-f
+
+[DB]
+filename = requests.db
+
+[JSON]
+indentation = 2
+
+[SORT_BY]
+# Column options: name, timestamp, url, method, body, authtype, authuser,
+# authpass, headers
+# Order options: asc, desc
+column = timestamp
+order = asc
+
+[STYLE]
+# More styles here:
+# https://bitbucket.org/birkenfeld/pygments-main/src/stable/pygments/styles
+theme = default
+separator_line_fg = gray
+separator_line_bg = black

--- a/examples/torch_kernel/params.xml
+++ b/examples/torch_kernel/params.xml
@@ -1,0 +1,19 @@
+<ForceField>
+  <AtomTypes>
+    <Type class="ar" element="Ar" mass="39.948" name="ar"/>
+    <Type class="ne" element="Ne" mass="20.1797" name="ne"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="ARG">
+      <Atom charge="0.0" name="AR" type="ar"/>
+    </Residue>
+    <Residue name="NEO">
+      <Atom charge="0.0" name="NE" type="ne"/>
+    </Residue>
+  </Residues>
+  <NonbondedForce lj14scale="1.0">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="1.00" sigma="0.34" type="ar"/>
+    <Atom epsilon="0.50" sigma="0.31" type="ne"/>
+  </NonbondedForce>
+</ForceField>

--- a/examples/torch_kernel/residues.xml
+++ b/examples/torch_kernel/residues.xml
@@ -1,0 +1,8 @@
+  <Residues>
+    <Residue name="ARG">
+      <Atom name="AR" type="ar"/>
+    </Residue>
+    <Residue name="NEO">
+      <Atom name="NE" type="ne"/>
+    </Residue>
+  </Residues>

--- a/examples/torch_kernel/run.py
+++ b/examples/torch_kernel/run.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+import openmm.app as app
+import openmm.unit as unit
+from dmff.api import Hamiltonian
+from dmff.common import nblist
+import numpy as np
+import jax
+import jax.numpy as jnp
+import torch
+from torch2jax import j2t, t2j
+from dmff.torch_tools import wrap_torch_potential_kernel, j2t_pytree, t2j_pytree
+
+
+# manual implementation of the LJ kernel
+atomtypes = np.array((0, 0, 1))
+def potential_t(positions, box, pairs, params):
+    sigmas_atoms = params["NonbondedForce"]["sigma"][atomtypes]
+    epsilons_atoms = params["NonbondedForce"]["epsilon"][atomtypes]
+    sigma1_list = sigmas_atoms[pairs[:, 0]]
+    sigma2_list = sigmas_atoms[pairs[:, 1]]
+    epsilon1_list = epsilons_atoms[pairs[:, 0]]
+    epsilon2_list = epsilons_atoms[pairs[:, 1]]
+    # sigma_list = torch.sqrt(sigma1_list * sigma2_list)
+    sigma_list = (sigma1_list + sigma2_list)/2
+    epsilon_list = torch.sqrt(epsilon1_list * epsilon2_list)
+    r1 = positions[pairs[:, 0]]
+    r2 = positions[pairs[:, 1]]
+    dr = r1 - r2
+    dr2 = torch.sum(dr * dr, dim=1)
+    sigma_dr2 = sigma_list * sigma_list / dr2
+    energies = 4 * epsilon_list * ((sigma_dr2)**6 - (sigma_dr2)**3)
+    return torch.sum(energies)
+
+
+if __name__ == '__main__':
+    H = Hamiltonian('params.xml')
+    params = H.getParameters().parameters
+    app.Topology.loadBondDefinitions("residues.xml")
+    pdb = app.PDBFile("structure.pdb")
+    rc = 1.0
+
+    pots = H.createPotential(pdb.topology, \
+                             nonbondedMethod=app.CutoffPeriodic, \
+                             nonbondedCutoff=rc*unit.nanometer)
+
+    potential_jax = pots.dmff_potentials['NonbondedForce']
+
+    # construct inputs
+    positions = jnp.array(pdb.positions._value)
+    a, b, c = pdb.topology.getPeriodicBoxVectors()
+    box = jnp.array([a._value, b._value, c._value])
+    # neighbor list
+    nbl = nblist.NeighborList(box, rc, pots.meta['cov_map']) 
+    nbl.allocate(positions)
+
+
+    # native jax implementation
+    pairs = np.array(nbl.pairs)
+    ene, p_grad = jax.value_and_grad(potential_jax, argnums=3)(positions, box, nbl.pairs, params)
+
+    print("JAX kernel results:")
+    print(p_grad["NonbondedForce"]["sigma"])
+    print(p_grad["NonbondedForce"]["epsilon"])
+
+    # torch input and kernel
+    positions_t = j2t_pytree(positions)
+    box_t = j2t_pytree(box)
+    params_t = j2t_pytree(params)
+    ene = potential_t(positions_t, box_t, pairs, params_t)
+    ene.backward()
+    print("Torch kernel results:")
+    print(params_t["NonbondedForce"]["sigma"].grad)
+    print(params_t["NonbondedForce"]["epsilon"].grad)
+
+    # Wrapping torch with JAX
+    potential_wrapped = wrap_torch_potential_kernel(potential_t)
+    ene, p_grad = jax.value_and_grad(potential_wrapped, argnums=3)(positions, box, nbl.pairs, params)
+    print("Wrapped Torch kernel results:")
+    print(p_grad["NonbondedForce"]["sigma"])
+    print(p_grad["NonbondedForce"]["epsilon"])

--- a/examples/torch_kernel/structure.pdb
+++ b/examples/torch_kernel/structure.pdb
@@ -1,0 +1,6 @@
+REMARK   1 CREATED WITH OPENMM 8.0, 2023-08-25
+CRYST1   30.000   30.000   30.000  90.00  90.00  90.00 P 1           1 
+HETATM    1  AR  ARG A   1       4.125  13.679  13.761  1.00  0.00          Ar  
+HETATM    2  AR  ARG A   2       5.406  17.008  13.462  1.00  0.00          Ar  
+HETATM    3  NE  NEO A   3       7.292  15.267  11.931  1.00  0.00          Ne
+END

--- a/examples/torch_kernel/structure1.pdb
+++ b/examples/torch_kernel/structure1.pdb
@@ -1,0 +1,6 @@
+REMARK   1 CREATED WITH OPENMM 8.0, 2023-08-25
+CRYST1   30.000   30.000   30.000  90.00  90.00  90.00 P 1           1 
+HETATM    1  AR  ARG A   1       4.125  13.679  13.761  1.00  0.00          Ar  
+HETATM    2  AR  ARG A   2       5.406  17.008  13.462  1.00  0.00          Ar  
+HETATM    3  NE  NEO A   3       7.292  15.267  11.931  1.00  0.00          Ne
+END


### PR DESCRIPTION
Add a wrapper in dmff.torch_tools, to wrap a torch potential kernel to make it compatible with the dmff jax environment